### PR TITLE
Add demo MCP platform wrapping customer API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# MCP---Platform---test
+# MCP Platform Demo
+
+本项目提供一个可以在本地快速运行的示例，演示「客户系统接口 → MCP 平台 → Dify」的完整链路。所有服务均使用 Python 标准库实现，方便在任何环境下运行。
+
+## 目录结构
+
+- `customer_api/`：模拟客户系统对外开放的 HTTP 接口。
+- `mcp_platform/`：对客户接口进行包装的 MCP 平台，实现统一返回格式、鉴权与审计。
+- `dify_client/`：示例脚本，演示如何在 Dify 中以 HTTP Tool 方式调用 MCP 平台。
+- `run_demo.py`：同时启动客户接口与 MCP 平台，方便体验。
+
+## 快速开始
+
+1. 启动两个服务：
+
+   ```bash
+   python run_demo.py
+   ```
+
+   终端会显示客户接口与 MCP 平台监听的地址：
+
+   - 客户接口：<http://127.0.0.1:8001/api/orders>
+   - MCP 平台：<http://127.0.0.1:8010/tools/orders>
+
+   MCP 平台默认要求请求头中携带 `X-MCP-Key: mcp-demo-key`。
+
+2. 打开新的终端窗口，演示一次 Dify（或任何 HTTP 调用方）的调用：
+
+   ```bash
+   python dify_client/demo_call.py
+   ```
+
+   你将看到 MCP 平台返回的标准化 JSON，其中包含原始数据与附加的元信息。
+
+## 在 Dify 中接入
+
+1. 在 Dify 后台创建一个「HTTP 请求」工具。
+2. 填写 URL 为 `http://127.0.0.1:8010/tools/orders`。
+3. 在 Headers 中增加 `X-MCP-Key: mcp-demo-key`。
+4. 触发工具即可获取包装后的订单信息；如需查询单个订单，可在 URL 后追加订单号，例如 `http://127.0.0.1:8010/tools/orders/A1001`。
+
+## 配置项
+
+| 环境变量        | 默认值                      | 说明                           |
+| --------------- | --------------------------- | ------------------------------ |
+| `CUSTOMER_API_BASE` | `http://127.0.0.1:8001` | MCP 平台访问客户接口时使用的地址 |
+| `MCP_API_KEY`       | `mcp-demo-key`            | MCP 平台校验请求头 `X-MCP-Key`  |
+
+## 终止服务
+
+运行 `run_demo.py` 的终端按下 `Ctrl+C` 即可优雅退出两个服务。
+
+## 开发说明
+
+项目不依赖任何第三方库，所有逻辑均在少量 Python 文件内实现，便于阅读与扩展。你可以根据业务需要补充更多工具端点、请求参数校验或审计机制。

--- a/customer_api/server.py
+++ b/customer_api/server.py
@@ -1,0 +1,113 @@
+"""Simple customer-facing API implemented with only the Python standard library.
+
+The module exposes a WSGI application so it can be served by ``wsgiref.simple_server``
+for local demos or unit tests.  It mimics a small portion of a customer system
+that will later be wrapped by the MCP platform.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Callable, Iterable, Tuple
+
+Headers = list[Tuple[str, str]]
+StartResponse = Callable[[str, Headers], Callable[[bytes], object]]
+
+
+def _json_response(status: str, payload: dict) -> Tuple[str, Headers, bytes]:
+    body = json.dumps(payload).encode("utf-8")
+    headers: Headers = [
+        ("Content-Type", "application/json; charset=utf-8"),
+        ("Content-Length", str(len(body))),
+        ("Cache-Control", "no-store"),
+    ]
+    return status, headers, body
+
+
+def _not_found(path: str) -> Tuple[str, Headers, bytes]:
+    return _json_response(
+        "404 Not Found",
+        {
+            "error": "not_found",
+            "message": f"The resource {path!r} does not exist in the customer API.",
+        },
+    )
+
+
+def _orders() -> dict:
+    """Return a deterministic payload for the ``/api/orders`` endpoint."""
+
+    now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    return {
+        "generated_at": now,
+        "orders": [
+            {
+                "order_id": "A1001",
+                "status": "processing",
+                "total": 512.43,
+                "currency": "CNY",
+                "items": [
+                    {"sku": "SKU-1", "quantity": 2, "unit_price": 199.0},
+                    {"sku": "SKU-5", "quantity": 1, "unit_price": 114.43},
+                ],
+            },
+            {
+                "order_id": "A1002",
+                "status": "shipped",
+                "total": 79.99,
+                "currency": "CNY",
+                "items": [
+                    {"sku": "SKU-8", "quantity": 4, "unit_price": 19.99},
+                ],
+            },
+        ],
+    }
+
+
+def _order(order_id: str) -> dict | None:
+    for order in _orders()["orders"]:
+        if order["order_id"] == order_id:
+            return order
+    return None
+
+
+def application(environ: dict, start_response: StartResponse) -> Iterable[bytes]:
+    """WSGI entry point for the demo API."""
+
+    path = environ.get("PATH_INFO") or "/"
+
+    if path == "/" or path == "/health":
+        status, headers, body = _json_response(
+            "200 OK",
+            {"status": "healthy", "service": "customer-api"},
+        )
+    elif path == "/api/orders":
+        status, headers, body = _json_response("200 OK", _orders())
+    elif path.startswith("/api/orders/"):
+        order_id = path.rsplit("/", 1)[-1]
+        order = _order(order_id)
+        if order is None:
+            status, headers, body = _not_found(path)
+        else:
+            status, headers, body = _json_response("200 OK", order)
+    else:
+        status, headers, body = _not_found(path)
+
+    write = start_response(status, headers)
+    write(body)
+    return []
+
+
+def run(host: str = "127.0.0.1", port: int = 8001) -> None:
+    """Run the server using ``wsgiref.simple_server`` for local testing."""
+
+    from wsgiref.simple_server import make_server
+
+    with make_server(host, port, application) as httpd:
+        print(f"Customer API listening on http://{host}:{port}")
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    run()

--- a/dify_client/demo_call.py
+++ b/dify_client/demo_call.py
@@ -1,0 +1,42 @@
+"""Utility script that demonstrates how Dify (or any HTTP client) can call the
+wrapped MCP endpoint.
+
+The script sends a GET request with the required ``X-MCP-Key`` header and
+prints the transformed response in a human-friendly way.  It uses only the
+standard library so it can run in this execution environment.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+MCP_BASE = os.environ.get("MCP_BASE", "http://127.0.0.1:8010")
+API_KEY = os.environ.get("MCP_API_KEY", "mcp-demo-key")
+
+
+def main() -> None:
+    url = f"{MCP_BASE}/tools/orders"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "X-MCP-Key": API_KEY,
+            "User-Agent": "dify-demo-client/1.0",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            data = json.loads(response.read().decode(response.headers.get_content_charset("utf-8")))
+    except urllib.error.URLError as exc:  # pragma: no cover - demo script
+        raise SystemExit(f"Failed to call MCP endpoint {url}: {exc}") from exc
+
+    print("Response from MCP platform:\n")
+    print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp_platform/server.py
+++ b/mcp_platform/server.py
@@ -1,0 +1,158 @@
+"""Minimal MCP-like wrapper around the customer API.
+
+The goal of this module is to demonstrate how an organisation might wrap its
+internal/customer API with a layer that provides:
+
+* Normalised output format and metadata that is friendly to LLM tooling.
+* Lightweight authentication using an API key in the ``X-MCP-Key`` header.
+* Request logging to make it easy to audit calls coming from the AI platform.
+
+The implementation uses only the Python standard library so it can run in the
+execution environment provided for the kata.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from http import HTTPStatus
+from typing import Callable, Iterable, Tuple
+
+Headers = list[Tuple[str, str]]
+StartResponse = Callable[[str, Headers], Callable[[bytes], object]]
+
+DEFAULT_PORT = 8010
+
+
+class RequestLogger:
+    """Thread-safe, in-memory request logger used for the demo."""
+
+    def __init__(self) -> None:
+        self._entries: list[str] = []
+        self._lock = threading.Lock()
+
+    def log(self, message: str) -> None:
+        timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
+        line = f"[{timestamp}] {message}"
+        with self._lock:
+            self._entries.append(line)
+        print(line, file=sys.stderr)
+
+    def as_dict(self) -> dict:
+        with self._lock:
+            return {"entries": list(self._entries)}
+
+
+LOGGER = RequestLogger()
+
+
+def _json_response(status: HTTPStatus, payload: dict) -> Tuple[str, Headers, bytes]:
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    headers: Headers = [
+        ("Content-Type", "application/json; charset=utf-8"),
+        ("Content-Length", str(len(body))),
+        ("Cache-Control", "no-store"),
+    ]
+    return f"{status.value} {status.phrase}", headers, body
+
+
+def _error(status: HTTPStatus, message: str, *, code: str) -> Tuple[str, Headers, bytes]:
+    return _json_response(status, {"error": code, "message": message})
+
+
+def _require_api_key(environ: dict) -> bool:
+    expected_key = os.environ.get("MCP_API_KEY", "mcp-demo-key")
+    provided = environ.get("HTTP_X_MCP_KEY")
+    return provided == expected_key
+
+
+def _call_customer_api(path: str) -> Tuple[int, dict]:
+    base_url = os.environ.get("CUSTOMER_API_BASE", "http://127.0.0.1:8001")
+    url = f"{base_url}{path}"
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            charset = response.headers.get_content_charset("utf-8")
+            payload = json.loads(response.read().decode(charset))
+            return response.status, payload
+    except urllib.error.HTTPError as exc:  # Customer API returned error
+        try:
+            payload = json.loads(exc.read().decode("utf-8"))
+        except Exception:  # pragma: no cover - defensive
+            payload = {"error": "customer_api_error", "message": str(exc)}
+        return exc.code, payload
+    except urllib.error.URLError as exc:
+        return 503, {
+            "error": "unreachable",
+            "message": f"Failed to reach customer API at {url}: {exc.reason}",
+        }
+
+
+def application(environ: dict, start_response: StartResponse) -> Iterable[bytes]:
+    path = environ.get("PATH_INFO") or "/"
+
+    if path == "/" or path == "/health":
+        status, headers, body = _json_response(
+            HTTPStatus.OK,
+            {
+                "status": "healthy",
+                "service": "mcp-platform",
+                "customer_api": os.environ.get("CUSTOMER_API_BASE", "http://127.0.0.1:8001"),
+            },
+        )
+    elif path == "/logs":
+        status, headers, body = _json_response(HTTPStatus.OK, LOGGER.as_dict())
+    elif path.startswith("/tools/orders"):
+        if not _require_api_key(environ):
+            status, headers, body = _error(
+                HTTPStatus.UNAUTHORIZED,
+                "Missing or invalid X-MCP-Key header.",
+                code="unauthorised",
+            )
+        else:
+            LOGGER.log(f"orders endpoint requested: path={path}")
+            customer_path = "/api/orders"
+            if path != "/tools/orders":
+                suffix = path[len("/tools") :]
+                customer_path = suffix.replace("/tools", "")
+                customer_path = customer_path.replace("/orders", "/api/orders", 1)
+            status_code, payload = _call_customer_api(customer_path)
+            metadata = {
+                "source": "customer-api",
+                "transformed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            }
+            try:
+                status_enum = HTTPStatus(status_code)
+            except ValueError:  # pragma: no cover - defensive
+                status_enum = HTTPStatus.BAD_GATEWAY
+            status, headers, body = _json_response(
+                status_enum,
+                {"metadata": metadata, "data": payload},
+            )
+    else:
+        status, headers, body = _error(
+            HTTPStatus.NOT_FOUND,
+            f"Unknown resource {path!r} on MCP platform.",
+            code="not_found",
+        )
+
+    writer = start_response(status, headers)
+    writer(body)
+    return []
+
+
+def run(host: str = "127.0.0.1", port: int = DEFAULT_PORT) -> None:
+    from wsgiref.simple_server import make_server
+
+    with make_server(host, port, application) as httpd:
+        print(f"MCP platform listening on http://{host}:{port}")
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    run()

--- a/run_demo.py
+++ b/run_demo.py
@@ -1,0 +1,57 @@
+"""Run both the customer API and the MCP wrapper in the same process.
+
+This helper is convenient for local demos, unit tests or to record screenshots.
+"""
+
+from __future__ import annotations
+
+import signal
+import threading
+import time
+from contextlib import contextmanager
+from typing import Iterator
+
+from customer_api.server import application as customer_app
+from mcp_platform.server import DEFAULT_PORT, application as mcp_app
+
+
+@contextmanager
+def _serve(app, port: int) -> Iterator[None]:
+    from wsgiref.simple_server import make_server
+
+    server = make_server("127.0.0.1", port, app)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+def main() -> None:
+    customer_port = 8001
+    mcp_port = DEFAULT_PORT
+
+    print("Starting demo services...\n")
+    with _serve(customer_app, customer_port), _serve(mcp_app, mcp_port):
+        print("Customer API available at http://127.0.0.1:8001/api/orders")
+        print("MCP platform available at http://127.0.0.1:8010/tools/orders")
+        print("Press Ctrl+C to stop.")
+
+        stop = threading.Event()
+
+        def _handle_signal(signum, frame):
+            print("\nShutting down...")
+            stop.set()
+
+        signal.signal(signal.SIGINT, _handle_signal)
+        signal.signal(signal.SIGTERM, _handle_signal)
+
+        while not stop.is_set():
+            time.sleep(0.2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+import unittest
+import urllib.request
+from contextlib import contextmanager
+
+from customer_api.server import application as customer_app
+from mcp_platform.server import DEFAULT_PORT, application as mcp_app
+
+
+@contextmanager
+def serve(app, port: int):
+    from wsgiref.simple_server import make_server
+
+    server = make_server("127.0.0.1", port, app)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+class EndToEndTestCase(unittest.TestCase):
+    def test_orders_flow(self) -> None:
+        with serve(customer_app, 8001), serve(mcp_app, DEFAULT_PORT):
+            time.sleep(0.1)  # allow servers to bind
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{DEFAULT_PORT}/tools/orders",
+                headers={"X-MCP-Key": "mcp-demo-key"},
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
+                data = json.loads(response.read().decode("utf-8"))
+
+        self.assertIn("metadata", data)
+        self.assertIn("data", data)
+        self.assertIn("orders", data["data"])
+        self.assertGreater(len(data["data"]["orders"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement a simulated customer API and wrap it with an MCP platform that standardises responses, adds API-key auth, and exposes logs
- provide a demo client plus documentation showing how to call the MCP endpoint from Dify
- add an automated end-to-end test that exercises the full flow

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68d115a9ef148322bfc1c7a626ac5eca