### PR TITLE
Expose manifest-driven MCP HTTP service with fallback data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# MCP---Platform---test
+# MCP Platform Demo
+
+本项目提供一个可以在本地快速运行的示例，演示「客户系统接口 → MCP 平台 → Dify」的完整链路。服务采用 Python 标准库实现，部署轻量。
+
+## 目录结构
+
+- `customer_api/`：模拟客户系统对外开放的 HTTP 接口。
+- `mcp_platform/`：对客户接口进行包装的 MCP 平台，暴露符合 MCP HTTP 规范的工具并提供日志、降级能力。
+- `dify_client/`：示例脚本，演示如何以 MCP HTTP 工具方式调用包装后的接口。
+- `run_demo.py`：同时启动客户接口与 MCP 平台，方便体验。
+- `tests/`：自动化用例验证端到端链路以及降级逻辑。
+
+## 快速开始
+
+1. 启动两个服务：
+
+   ```bash
+   python run_demo.py
+   ```
+
+   终端会显示以下信息：
+
+   - 客户接口：<http://127.0.0.1:8001/api/orders>
+   - MCP Manifest：<http://127.0.0.1:8010/.well-known/mcp.json>
+   - MCP 工具端点：<http://127.0.0.1:8010/mcp/tools/orders>
+
+   MCP 平台默认不校验 API Key，如需开启，可设置环境变量 `MCP_API_KEY`。
+
+2. 新开一个终端验证调用：
+
+   ```bash
+   python dify_client/demo_call.py
+   ```
+
+   如输出中 `metadata.source` 为 `customer-api`，表示请求已经穿透到客户系统；若客户接口不可达，则会自动降级为 `sample-data`，依旧返回稳定的模拟数据。
+
+## 在 Dify 中接入 MCP HTTP 服务
+
+1. 在 Dify 后台选择「工具」→「MCP」→「添加 MCP 服务 (HTTP)」。
+2. 将 URL 设置为 `http://127.0.0.1:8010`（注意填写服务根地址，Dify 会自动读取 `/.well-known/mcp.json`）。
+3. 若启用了 API Key 校验，可在 Dify 中补充 `X-MCP-Key` 请求头。
+4. 授权成功后即可在工作流或 Agent 中调用 `orders` 工具，获取订单列表或传入 `order_id` 查询单个订单。
+
+> **提示**：即使客户接口暂不可用，MCP 平台也会返回内置的示例数据，保证接入过程中不会报错。
+
+## 配置项
+
+| 环境变量            | 默认值                    | 说明                               |
+| ------------------- | ------------------------- | ---------------------------------- |
+| `CUSTOMER_API_BASE` | `http://127.0.0.1:8001`   | MCP 平台访问客户接口时使用的地址   |
+| `MCP_API_KEY`       | 未设置（不校验）         | MCP 平台校验请求头 `X-MCP-Key` 的值 |
+
+## 终止服务
+
+运行 `run_demo.py` 的终端按下 `Ctrl+C` 即可结束两个服务。
+
+## 开发说明
+
+项目不依赖第三方库，逻辑集中在少量 Python 文件中，便于理解和扩展。你可以在 MCP 平台中继续添加更多工具、审计字段或鉴权逻辑。

--- a/customer_api/data.py
+++ b/customer_api/data.py
@@ -1,0 +1,53 @@
+"""Shared sample data used by the customer API and the MCP wrapper."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+_SAMPLE_ORDERS: list[dict[str, Any]] = [
+    {
+        "order_id": "A1001",
+        "status": "processing",
+        "total": 512.43,
+        "currency": "CNY",
+        "items": [
+            {"sku": "SKU-1", "quantity": 2, "unit_price": 199.0},
+            {"sku": "SKU-5", "quantity": 1, "unit_price": 114.43},
+        ],
+    },
+    {
+        "order_id": "A1002",
+        "status": "shipped",
+        "total": 79.99,
+        "currency": "CNY",
+        "items": [
+            {"sku": "SKU-8", "quantity": 4, "unit_price": 19.99},
+        ],
+    },
+    {
+        "order_id": "A1003",
+        "status": "ready_for_pickup",
+        "total": 1499.0,
+        "currency": "CNY",
+        "items": [
+            {"sku": "SKU-9", "quantity": 1, "unit_price": 1499.0},
+        ],
+    },
+]
+
+
+def list_orders_payload() -> dict[str, Any]:
+    """Return the payload used for ``/api/orders``."""
+
+    generated_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    return {"generated_at": generated_at, "orders": list(_SAMPLE_ORDERS)}
+
+
+def get_order_payload(order_id: str) -> dict[str, Any] | None:
+    """Return a single order dict if it exists."""
+
+    for order in _SAMPLE_ORDERS:
+        if order["order_id"] == order_id:
+            return dict(order)
+    return None

--- a/customer_api/server.py
+++ b/customer_api/server.py
@@ -1,0 +1,72 @@
+"""Simple customer-facing API implemented with only the Python standard library."""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, Iterable, Tuple
+
+from . import data
+
+Headers = list[Tuple[str, str]]
+StartResponse = Callable[[str, Headers], Callable[[bytes], object]]
+
+
+def _json_response(status: str, payload: dict) -> Tuple[str, Headers, bytes]:
+    body = json.dumps(payload).encode("utf-8")
+    headers: Headers = [
+        ("Content-Type", "application/json; charset=utf-8"),
+        ("Content-Length", str(len(body))),
+        ("Cache-Control", "no-store"),
+    ]
+    return status, headers, body
+
+
+def _not_found(path: str) -> Tuple[str, Headers, bytes]:
+    return _json_response(
+        "404 Not Found",
+        {
+            "error": "not_found",
+            "message": f"The resource {path!r} does not exist in the customer API.",
+        },
+    )
+
+
+def application(environ: dict, start_response: StartResponse) -> Iterable[bytes]:
+    """WSGI entry point for the demo API."""
+
+    path = environ.get("PATH_INFO") or "/"
+
+    if path == "/" or path == "/health":
+        status, headers, body = _json_response(
+            "200 OK",
+            {"status": "healthy", "service": "customer-api"},
+        )
+    elif path == "/api/orders":
+        status, headers, body = _json_response("200 OK", data.list_orders_payload())
+    elif path.startswith("/api/orders/"):
+        order_id = path.rsplit("/", 1)[-1]
+        order = data.get_order_payload(order_id)
+        if order is None:
+            status, headers, body = _not_found(path)
+        else:
+            status, headers, body = _json_response("200 OK", order)
+    else:
+        status, headers, body = _not_found(path)
+
+    write = start_response(status, headers)
+    write(body)
+    return []
+
+
+def run(host: str = "127.0.0.1", port: int = 8001) -> None:
+    """Run the server using ``wsgiref.simple_server`` for local testing."""
+
+    from wsgiref.simple_server import make_server
+
+    with make_server(host, port, application) as httpd:
+        print(f"Customer API listening on http://{host}:{port}")
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    run()

--- a/dify_client/demo_call.py
+++ b/dify_client/demo_call.py
@@ -1,0 +1,30 @@
+"""Demo script that exercises the MCP HTTP service using urllib."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+
+MCP_BASE = os.environ.get("MCP_BASE", "http://127.0.0.1:8010")
+API_KEY = os.environ.get("MCP_API_KEY")
+
+
+def main() -> None:
+    url = f"{MCP_BASE}/mcp/tools/orders"
+    request = urllib.request.Request(url, method="POST")
+    body = json.dumps({"order_id": "A1001"}).encode("utf-8")
+    request.data = body
+    request.add_header("Content-Type", "application/json")
+    if API_KEY:
+        request.add_header("X-MCP-Key", API_KEY)
+
+    with urllib.request.urlopen(request, timeout=10) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+
+    print("Response from MCP platform:\n")
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp_platform/server.py
+++ b/mcp_platform/server.py
@@ -1,0 +1,280 @@
+"""HTTP MCP wrapper that exposes the customer API as MCP tools."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import urllib.error
+import urllib.request
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from customer_api import data as sample_data
+
+DEFAULT_PORT = 8010
+_MANIFEST_SCHEMA_VERSION = "2024-05-24"
+
+
+class RequestLog:
+    """Thread-safe request log for demo observability."""
+
+    def __init__(self) -> None:
+        self._entries: list[dict[str, Any]] = []
+        self._lock = threading.Lock()
+
+    def record(self, *, method: str, path: str, status: int, metadata: dict[str, Any] | None) -> None:
+        entry = {
+            "time": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "method": method,
+            "path": path,
+            "status": status,
+        }
+        if metadata:
+            entry["metadata"] = metadata
+        with self._lock:
+            self._entries.append(entry)
+
+    def as_dict(self) -> dict[str, Any]:
+        with self._lock:
+            return {"entries": list(self._entries)}
+
+
+REQUEST_LOG = RequestLog()
+
+
+def _customer_api_base() -> str:
+    return os.environ.get("CUSTOMER_API_BASE", "http://127.0.0.1:8001")
+
+
+def _expected_api_key() -> str | None:
+    key = os.environ.get("MCP_API_KEY")
+    return key or None
+
+
+def _fallback_from_sample(order_id: str | None) -> tuple[int, dict[str, Any]]:
+    if order_id:
+        order = sample_data.get_order_payload(order_id)
+        if order is None:
+            return HTTPStatus.NOT_FOUND, {
+                "error": "not_found",
+                "message": f"Order {order_id} was not found in sample data.",
+            }
+        return HTTPStatus.OK, order
+    return HTTPStatus.OK, sample_data.list_orders_payload()
+
+
+def _fetch_orders(order_id: str | None) -> tuple[int, dict[str, Any], dict[str, Any]]:
+    path = "/api/orders" + (f"/{order_id}" if order_id else "")
+    base_url = _customer_api_base()
+    url = f"{base_url}{path}"
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            charset = response.headers.get_content_charset("utf-8")
+            payload = json.loads(response.read().decode(charset))
+            metadata = {"source": "customer-api", "url": url}
+            return response.status, payload, metadata
+    except urllib.error.HTTPError as exc:
+        try:
+            charset = exc.headers.get_content_charset("utf-8")
+            payload = json.loads(exc.read().decode(charset or "utf-8"))
+        except Exception:  # pragma: no cover - defensive
+            payload = {"error": "customer_api_error", "message": str(exc)}
+        metadata = {
+            "source": "customer-api",
+            "url": url,
+            "status": exc.code,
+        }
+        return exc.code, payload, metadata
+    except urllib.error.URLError as exc:
+        status, payload = _fallback_from_sample(order_id)
+        reason = getattr(exc, "reason", exc)
+        metadata = {
+            "source": "sample-data",
+            "url": url,
+            "customer_api_error": str(reason),
+        }
+        return status, payload, metadata
+
+
+def _manifest() -> dict[str, Any]:
+    return {
+        "schema_version": _MANIFEST_SCHEMA_VERSION,
+        "name": "demo-orders-mcp",
+        "version": "1.0.0",
+        "description": "Expose customer orders via the Model Context Protocol.",
+        "tools": [
+            {
+                "name": "orders",
+                "description": "List all orders or fetch a single order when `order_id` is provided.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "order_id": {
+                            "type": "string",
+                            "description": "Optional order identifier. When set the tool returns only that order.",
+                        }
+                    },
+                },
+            }
+        ],
+    }
+
+
+class MCPRequestHandler(BaseHTTPRequestHandler):
+    server_version = "DemoMCP/1.0"
+
+    def _send_json(self, status: int, payload: dict[str, Any], *, metadata: dict[str, Any] | None = None) -> None:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+        REQUEST_LOG.record(method=self.command, path=self.path, status=status, metadata=metadata)
+
+    def _require_api_key(self) -> bool:
+        expected = _expected_api_key()
+        if expected is None:
+            return True
+        provided = self.headers.get("X-MCP-Key")
+        if provided == expected:
+            return True
+        self._send_json(
+            HTTPStatus.UNAUTHORIZED,
+            {
+                "error": "unauthorised",
+                "message": "Missing or invalid X-MCP-Key header.",
+            },
+            metadata={"reason": "invalid_api_key"},
+        )
+        return False
+
+    def do_OPTIONS(self) -> None:  # pragma: no cover - simple boilerplate
+        self.send_response(204)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, X-MCP-Key")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.end_headers()
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path == "/" or parsed.path == "/mcp/health":
+            self._send_json(HTTPStatus.OK, {"status": "healthy", "service": "mcp-platform"})
+        elif parsed.path == "/.well-known/mcp.json":
+            self._send_json(HTTPStatus.OK, _manifest())
+        elif parsed.path == "/mcp/logs":
+            self._send_json(HTTPStatus.OK, REQUEST_LOG.as_dict())
+        elif parsed.path == "/mcp/tools/orders":
+            if not self._require_api_key():
+                return
+            params = parse_qs(parsed.query)
+            order_id = params.get("order_id", [None])[0]
+            self._handle_orders(order_id)
+        else:
+            self._send_json(
+                HTTPStatus.NOT_FOUND,
+                {
+                    "error": "not_found",
+                    "message": f"Unknown resource {parsed.path!r} on the MCP platform.",
+                },
+            )
+
+    def do_POST(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path == "/mcp/tools/orders":
+            if not self._require_api_key():
+                return
+            try:
+                length = int(self.headers.get("Content-Length", "0"))
+            except ValueError:
+                self._send_json(
+                    HTTPStatus.BAD_REQUEST,
+                    {"error": "invalid_length", "message": "Invalid Content-Length header."},
+                )
+                return
+
+            raw_body = self.rfile.read(length) if length else b"{}"
+            if not raw_body:
+                body: dict[str, Any] = {}
+            else:
+                try:
+                    body = json.loads(raw_body.decode("utf-8"))
+                except json.JSONDecodeError:
+                    self._send_json(
+                        HTTPStatus.BAD_REQUEST,
+                        {
+                            "error": "invalid_json",
+                            "message": "Request body must be valid JSON.",
+                        },
+                    )
+                    return
+            order_id = body.get("order_id")
+            if order_id is not None and not isinstance(order_id, str):
+                self._send_json(
+                    HTTPStatus.BAD_REQUEST,
+                    {
+                        "error": "invalid_order_id",
+                        "message": "order_id must be a string when provided.",
+                    },
+                )
+                return
+            self._handle_orders(order_id)
+        else:
+            self._send_json(
+                HTTPStatus.NOT_FOUND,
+                {
+                    "error": "not_found",
+                    "message": f"Unknown resource {parsed.path!r} on the MCP platform.",
+                },
+            )
+
+    def log_message(self, format: str, *args: Any) -> None:  # pragma: no cover - suppress default logging
+        return
+
+    def _handle_orders(self, order_id: str | None) -> None:
+        status, payload, metadata = _fetch_orders(order_id)
+        if status >= 400:
+            response = {
+                "error": payload.get("error", "customer_api_error"),
+                "message": payload.get("message", "Customer API returned an error."),
+                "data": payload,
+            }
+            self._send_json(status, response, metadata=metadata)
+            return
+
+        response = {
+            "tool": "orders",
+            "metadata": metadata,
+            "data": payload,
+        }
+        self._send_json(status, response, metadata=metadata)
+
+
+def make_server(host: str = "127.0.0.1", port: int = DEFAULT_PORT) -> ThreadingHTTPServer:
+    """Create a ThreadingHTTPServer instance for embedding or tests."""
+
+    return ThreadingHTTPServer((host, port), MCPRequestHandler)
+
+
+def run(host: str = "127.0.0.1", port: int = DEFAULT_PORT) -> None:
+    server = make_server(host, port)
+    try:
+        print(f"MCP platform listening on http://{host}:{port}")
+        server.serve_forever()
+    except KeyboardInterrupt:  # pragma: no cover - interactive use
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    run()

--- a/run_demo.py
+++ b/run_demo.py
@@ -1,0 +1,49 @@
+"""Run both the customer API and the MCP wrapper in the same process."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from customer_api import server as customer_server
+from mcp_platform import server as mcp_server
+
+
+class ServerThread(threading.Thread):
+    def __init__(self, target, name: str) -> None:
+        super().__init__(daemon=True)
+        self._target = target
+        self._stopped = threading.Event()
+        self.name = name
+
+    def run(self) -> None:  # pragma: no cover - simple orchestration
+        try:
+            self._target()
+        finally:
+            self._stopped.set()
+
+    def wait_until_stopped(self) -> None:
+        self._stopped.wait()
+
+
+def main() -> None:  # pragma: no cover - convenience script
+    customer = ServerThread(lambda: customer_server.run(port=8001), name="customer-api")
+    mcp = ServerThread(lambda: mcp_server.run(port=8010), name="mcp-platform")
+
+    customer.start()
+    time.sleep(0.3)
+    mcp.start()
+
+    print("Customer API available at http://127.0.0.1:8001/api/orders")
+    print("MCP service manifest at http://127.0.0.1:8010/.well-known/mcp.json")
+    print("Orders tool endpoint http://127.0.0.1:8010/mcp/tools/orders")
+
+    try:
+        while customer.is_alive() and mcp.is_alive():
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("Stopping demo...")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,88 @@
+import json
+import threading
+import time
+import unittest
+import urllib.request
+from contextlib import contextmanager
+
+from customer_api.server import application as customer_app
+from mcp_platform import server as mcp_server
+
+
+@contextmanager
+def serve_customer(port: int):
+    from wsgiref.simple_server import make_server
+
+    server = make_server("127.0.0.1", port, customer_app)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+@contextmanager
+def serve_mcp(port: int):
+    server = mcp_server.make_server("127.0.0.1", port)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+class EndToEndTestCase(unittest.TestCase):
+    def test_manifest_and_orders_flow(self) -> None:
+        with serve_customer(8001), serve_mcp(mcp_server.DEFAULT_PORT):
+            time.sleep(0.2)
+
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{mcp_server.DEFAULT_PORT}/.well-known/mcp.json", timeout=5
+            ) as response:
+                manifest = json.loads(response.read().decode("utf-8"))
+
+            self.assertIn("tools", manifest)
+            self.assertEqual(manifest["tools"][0]["name"], "orders")
+
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{mcp_server.DEFAULT_PORT}/mcp/tools/orders", timeout=5
+            ) as response:
+                list_payload = json.loads(response.read().decode("utf-8"))
+
+            self.assertEqual(list_payload["tool"], "orders")
+            self.assertIn("orders", list_payload["data"])
+
+            url = f"http://127.0.0.1:{mcp_server.DEFAULT_PORT}/mcp/tools/orders"
+            body = json.dumps({"order_id": "A1001"}).encode("utf-8")
+            request = urllib.request.Request(
+                url,
+                data=body,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
+                detail_payload = json.loads(response.read().decode("utf-8"))
+
+        self.assertEqual(detail_payload["metadata"]["source"], "customer-api")
+        self.assertEqual(detail_payload["data"]["order_id"], "A1001")
+
+    def test_orders_fallback_when_customer_api_unavailable(self) -> None:
+        with serve_mcp(mcp_server.DEFAULT_PORT):
+            time.sleep(0.2)
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{mcp_server.DEFAULT_PORT}/mcp/tools/orders", timeout=5
+            ) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+
+        self.assertEqual(payload["metadata"]["source"], "sample-data")
+        self.assertGreater(len(payload["data"]["orders"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- rebuild the MCP wrapper as an HTTP service that exposes a manifest, tool endpoint and optional API-key auth expected by Dify
- share sample order data between the customer API and MCP service so requests succeed even if the upstream system is offline
- refresh the demo client, runner and documentation plus extend end-to-end tests to cover manifest handling and fallback behaviour

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68d115a9ef148322bfc1c7a626ac5eca